### PR TITLE
fix: fix modal state reset

### DIFF
--- a/component/src/components/ui/Dialog.jsx
+++ b/component/src/components/ui/Dialog.jsx
@@ -104,6 +104,13 @@ const FileUrlDialog = ({ isOpen, onClose, onSubmit, linkText, link, children }) 
   const [text, setText] = useState(linkText || ""); // Initialize with title if provided
   const [error, setError] = useState("");
 
+// Reset dialog state after submission
+  useEffect(() => {
+    if (isOpen) {
+      resetToDefault();
+    }
+  }, [isOpen, link, linkText]);
+
   const closeDialog = () => {
     resetToDefault();
     onClose();


### PR DESCRIPTION
# Description

Added a useEffect hook in the dialog component to reset the modal to default values when it is opened.This ensures that when the modal opens, the link and linkText values are cleared, providing a fresh form for the user to add a new link.

Fixes #46 
# All React Text Igniter Contribution checklist:

- [x] **The pull request does not introduce [breaking changes].**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
